### PR TITLE
only extra first address space

### DIFF
--- a/kvm_pirate/__main__.py
+++ b/kvm_pirate/__main__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+import logging
 from typing import NoReturn
 
 from .kvm import GuestError, find_vm
@@ -15,6 +16,7 @@ def die(msg: str) -> NoReturn:
 def main() -> None:
     if len(sys.argv) < 2:
         die(f"USAGE: {sys.argv[0]} pid")
+    logging.basicConfig(level=logging.DEBUG)
     try:
         pid = int(sys.argv[1])
     except ValueError as e:


### PR DESCRIPTION
Only x86 uses a second one for system managment mode, which we don't
care about because the kernel lives in the first one.